### PR TITLE
fix: correct staticcheck errors/warnings

### DIFF
--- a/assets/icons_test.go
+++ b/assets/icons_test.go
@@ -11,14 +11,14 @@ import (
 
 	"github.com/Yash-Handa/logo-ls/assets"
 	"github.com/Yash-Handa/logo-ls/internal/ctw"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 func TestFileIcons(t *testing.T) {
 	log.Println("Printing each supported file name and ext by the icon pack")
 
 	// get terminal width
-	terminalWidth, _, e := terminal.GetSize(int(os.Stdout.Fd()))
+	terminalWidth, _, e := term.GetSize(int(os.Stdout.Fd()))
 	if e != nil {
 		terminalWidth = 80
 	}
@@ -62,7 +62,7 @@ func TestFileIcons(t *testing.T) {
 
 func TestIconDisplay(t *testing.T) {
 	// get terminal width
-	terminalWidth, _, e := terminal.GetSize(int(os.Stdout.Fd()))
+	terminalWidth, _, e := term.GetSize(int(os.Stdout.Fd()))
 	if e != nil {
 		terminalWidth = 80
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,8 @@ require (
 	github.com/mattn/go-colorable v0.1.7
 	github.com/pborman/getopt/v2 v2.1.0
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
-	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
+	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
 	golang.org/x/net v0.0.0-20201224014010-6772e930b67b // indirect
 	golang.org/x/sys v0.0.0-20201223074533-0d417f636930 // indirect
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 )

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,6 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/pborman/getopt/v2 v2.0.0 h1:Tn8XVmhb93Wbc346Tk4P6KutfpMVp+iztUzkZrTSyB4=
-github.com/pborman/getopt/v2 v2.0.0/go.mod h1:4NtW75ny4eBw9fO1bhtNdYTlZKYX5/tBLtsOpwKIKd0=
 github.com/pborman/getopt/v2 v2.1.0 h1:eNfR+r+dWLdWmV8g5OlpyrTYHkhVNxHBdN2cCrJmOEA=
 github.com/pborman/getopt/v2 v2.1.0/go.mod h1:4NtW75ny4eBw9fO1bhtNdYTlZKYX5/tBLtsOpwKIKd0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/Yash-Handa/logo-ls/internal/sysState"
 	"github.com/pborman/getopt/v2"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 // flags with corresponding bit values
@@ -219,7 +219,7 @@ func Bootstrap() {
 	case *f_1:
 	default:
 		// screen width for custom tw
-		w, _, e := terminal.GetSize(int(os.Stdout.Fd()))
+		w, _, e := term.GetSize(int(os.Stdout.Fd()))
 		if e == nil {
 			if w == 0 {
 				// for systems that don’t support ‘TIOCGWINSZ’.

--- a/internal/ctw/ctw.go
+++ b/internal/ctw/ctw.go
@@ -47,7 +47,7 @@ func (w *CTW) AddRow(args ...string) {
 	w.nw = append(w.nw, len(args[2]))
 	w.gw = append(w.gw, len(args[3]))
 
-	if w.showIcon == false {
+	if !w.showIcon {
 		w.showIcon = len(args[1]) > 0
 	}
 
@@ -97,25 +97,19 @@ func (w *CTW) Flush(buf *bytes.Buffer) {
 			// not even first iteration done print similar to logo-ls -1
 			if len(widths) == 0 {
 				widths = make([][4]int, len(iw))
-				for i := range iw {
-					widths[i] = iw[i]
-				}
+				copy(widths, iw)
 			}
 			break
 		} else if totW >= w.termW/2 { // if total width of the ls block is more than half of terminal
 			// copy iw to widths
 			widths = make([][4]int, len(iw))
-			for i := range iw {
-				widths[i] = iw[i]
-			}
+			copy(widths, iw)
 		}
 
 		if cols == dn { // if content comes in one line of terminal
 			// copy widths to prevWidths
 			widths = make([][4]int, len(iw))
-			for i := range iw {
-				widths[i] = iw[i]
-			}
+			copy(widths, iw)
 			break
 		}
 	}

--- a/internal/ctw/longCtw.go
+++ b/internal/ctw/longCtw.go
@@ -59,7 +59,7 @@ func (l *LongCTW) Flush(buf *bytes.Buffer) {
 			if (1<<j)&skipCol > 0 {
 				continue
 			}
-			if f == false {
+			if !f {
 				fmt.Fprintf(buf, "%s", empty)
 			}
 

--- a/internal/ctw/utils.go
+++ b/internal/ctw/utils.go
@@ -10,7 +10,7 @@ var (
 )
 
 func DisplayColor(b bool) {
-	if b == false {
+	if !b {
 		noColor = ""
 		green = ""
 		brown = ""

--- a/internal/dir/formatterStuff.go
+++ b/internal/dir/formatterStuff.go
@@ -54,7 +54,7 @@ func lessFuncGenerator(d *dir) {
 		d.less = func(i, j int) bool {
 			if mainSort(d.files[i].ext, d.files[j].ext) {
 				return true
-			} else if strings.ToLower(d.files[i].ext) == strings.ToLower(d.files[j].ext) {
+			} else if strings.EqualFold(d.files[i].ext, d.files[j].ext) {
 				return mainSort(d.files[i].name+d.files[i].ext, d.files[j].name+d.files[j].ext)
 			} else {
 				return false
@@ -154,7 +154,7 @@ func getIcon(name, ext, indicator string) (icon, color string) {
 		if ok {
 			break
 		}
-		if len(name) == 0 || '.' == name[0] {
+		if len(name) == 0 || name[0] == '.' {
 			i = assets.Icon_Def["hiddendir"]
 			break
 		}
@@ -184,7 +184,7 @@ func getIcon(name, ext, indicator string) (icon, color string) {
 			break
 		}
 
-		if len(name) == 0 || '.' == name[0] {
+		if len(name) == 0 || name[0] == '.' {
 			i = assets.Icon_Def["hiddenfile"]
 			break
 		}


### PR DESCRIPTION
Ran `go mod tidy` and applied fixes for any warnings from gopls and staticcheck

fixes include:
  * Replace depricated `io/util` with `io` package
  * Replace depricated `crypto/x/terminal` with `x/term` package
  * Replace yoda conditions with standard conditional statements
  * Call `defer stdout.Close()` only after the stdout pipe is created
  * Replace `for` loop with go's built-in `copy` function for improved performance