### PR TITLE
feat: added hard link count in long mode

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/canta2899/logo-ls/ctw"
@@ -96,7 +97,7 @@ func (a *App) GetCtw() ctw.CTW {
 	var out ctw.CTW
 
 	if a.Config.LongListingMode != model.LongListingNone {
-		out = ctw.NewLongCTW(9)
+		out = ctw.NewLongCTW(10)
 	} else if a.Config.OneFilePerLine {
 		out = ctw.NewLongCTW(4)
 	} else {
@@ -138,6 +139,7 @@ func (a *App) Print(d *model.Directory) {
 			lineCtw.AddRow(
 				a.getBlockSize(v.Blocks),
 				v.Mode,
+				fmt.Sprintf(" %v", strconv.Itoa(int(v.NumHardLinks))),
 				v.Owner,
 				v.Group,
 				a.getFormattedSize(v.Size),
@@ -183,6 +185,7 @@ func (a *App) ProcessFiles(files []model.FileEntry) *model.Directory {
 
 		if isLong {
 			f.Mode = v.Mode().String()
+			f.NumHardLinks = format.GetHardLinkCount(v.AbsPath)
 			f.ModeBits = uint32(v.Mode())
 			f.Owner, f.Group = model.GetOwnerGroupInfo(v, a.Config.NoGroup, a.Config.LongListingMode)
 		}
@@ -234,6 +237,7 @@ func (a *App) ProcessDirectory(d *model.DirectoryEntry) (*model.Directory, error
 		if long {
 			t.Info.Mode = ds.Mode().String()
 			t.Info.ModeBits = uint32(ds.Mode())
+			t.Info.NumHardLinks = format.GetHardLinkCount(d.Name())
 			t.Info.Owner, t.Info.Group = model.GetOwnerGroupInfo(ds, a.Config.NoGroup, a.Config.LongListingMode)
 		}
 		if a.Config.ShowBlockSize {
@@ -270,6 +274,7 @@ func (a *App) ProcessDirectory(d *model.DirectoryEntry) (*model.Directory, error
 		if long {
 			f.Mode = v.Mode().String()
 			f.ModeBits = uint32(v.Mode())
+			f.NumHardLinks = format.GetHardLinkCount(fullpath)
 			f.Owner, f.Group = model.GetOwnerGroupInfo(v, a.Config.NoGroup, a.Config.LongListingMode)
 		}
 		if a.Config.ShowBlockSize {
@@ -326,6 +331,7 @@ func (a *App) ProcessDirectory(d *model.DirectoryEntry) (*model.Directory, error
 		if long {
 			t.Parent.Mode = pds.Mode().String()
 			t.Parent.ModeBits = uint32(pds.Mode())
+			t.Parent.NumHardLinks = format.GetHardLinkCount(pp)
 			t.Parent.Owner, t.Parent.Group = model.GetOwnerGroupInfo(pds, a.Config.NoGroup, a.Config.LongListingMode)
 		}
 		if a.Config.ShowBlockSize {

--- a/format/format.go
+++ b/format/format.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/canta2899/logo-ls/icons"
 	"github.com/canta2899/logo-ls/model"
@@ -97,6 +98,23 @@ func GetIndicator(name string, isLongMode bool) (i string) {
 		i = "*"
 	}
 	return i
+}
+
+func GetHardLinkCount(absPath string) uint16 {
+	// Get file info
+	fileInfo, err := os.Stat(absPath)
+	if err != nil {
+		return 0
+	}
+
+	// Get the underlying stat structure
+	stat, ok := fileInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0
+	}
+
+	// Return the number of hard links
+	return stat.Nlink
 }
 
 func IsLink(name string) bool {

--- a/model/dir.go
+++ b/model/dir.go
@@ -27,6 +27,7 @@ type Entry struct {
 	Size                 int64
 	Mode                 string
 	ModeBits             uint32
+	NumHardLinks         uint16
 	Owner, Group         string
 	Blocks               int64
 	GitStatus            string


### PR DESCRIPTION
Adds a counter that, for each file, displays the number of hard links like ls(coreutils) if long mode (`-l`) is enabled.

## New output

```
drwxr-xr-x  4  andrea 128   Jun 18 19:06:19 [38;2;224;177;077m󰝰[0m .        
drwxr-xr-x  21 andrea 672   Jan 25 03:38:51 [38;2;224;177;077m󰝰[0m ..       
-rw-r--r--  1  andrea 10784 Jan 25 03:38:25 [38;2;032;173;194m󰟓[0m app.go   
-rw-r--r--  1  andrea 1002  Jun 18 19:06:19 [38;2;032;173;194m󰟓[0m config.go

            ^
            | 
            + counter added here
```




