### PR TITLE
fix: casting hardlink datatype to uint64

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -100,7 +100,7 @@ func GetIndicator(name string, isLongMode bool) (i string) {
 	return i
 }
 
-func GetHardLinkCount(absPath string) uint16 {
+func GetHardLinkCount(absPath string) uint64 {
 	// Get file info
 	fileInfo, err := os.Stat(absPath)
 	if err != nil {
@@ -114,7 +114,7 @@ func GetHardLinkCount(absPath string) uint16 {
 	}
 
 	// Return the number of hard links
-	return stat.Nlink
+	return uint64(stat.Nlink)
 }
 
 func IsLink(name string) bool {

--- a/model/dir.go
+++ b/model/dir.go
@@ -27,7 +27,7 @@ type Entry struct {
 	Size                 int64
 	Mode                 string
 	ModeBits             uint32
-	NumHardLinks         uint16
+	NumHardLinks         uint64
 	Owner, Group         string
 	Blocks               int64
 	GitStatus            string


### PR DESCRIPTION
Casts the number of hard links returned by `fileInfo.Sys().(*syscall.Stat_t)` to `uint64` to avoid platform inconsistencies
