### PR TITLE
fix: -l also lists groups

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -112,11 +112,11 @@ func GetConfig() *app.Config {
 
 	switch {
 	case *longListingMode:
-		c.LongListingMode = model.LongListingDefault
+		c.LongListingMode = model.LongListingOwner
 	case *longListingGroup:
 		c.LongListingMode = model.LongListingGroup
 	case *longListingDefault:
-		c.LongListingMode = model.LongListingOwner
+		c.LongListingMode = model.LongListingDefault
 	}
 
 	c.TimeFormat = toTimeFormat(*timeFormat)


### PR DESCRIPTION
Fixes a bug on CLI flags parsing that was causing groups not to be listed together with their respective owner when the `-l` flag was passed. Now `-l` lists both owners and groups whilst `-o` lists only owners and `-g` lists only groups.
