### PR TITLE
feat: inode number can be shown

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	HumanReadable   bool
 	ShowBlockSize   bool
 	TerminalWidth   int
+	ShowInodeNumber bool
 }
 
 func NewConfig() *Config {
@@ -41,6 +42,7 @@ func NewConfig() *Config {
 		NoGroup:         false,
 		HumanReadable:   false,
 		ShowBlockSize:   false,
+		ShowInodeNumber: false,
 		TerminalWidth:   80,
 		TimeFormat:      time.Stamp,
 		FileList:        []string{},

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -39,7 +39,8 @@ func GetConfig() *app.Config {
 	recursive := getopt.BoolLong("recursive", 'R', "list subdirectories recursively")
 	gitStatus := getopt.BoolLong("git-status", 'D', "print git status of files")
 	disableColor := getopt.BoolLong("disable-color", 'c', "don't color icons, filenames and git status (use this to print to a file)")
-	disableIcon := getopt.BoolLong("disable-icon", 'i', "don't print icons of the files")
+	disableIcon := getopt.BoolLong("disable-icon", 'I', "don't print icons of the files")
+	showInodeNumber := getopt.BoolLong("inode", 'i', "print the index number of each file")
 	oneFilePerLine := getopt.Bool('1', "list one file per line.")
 	directory := getopt.BoolLong("directory", 'd', "list directories themselves, not their contents")
 	noGroup := getopt.BoolLong("no-group", 'G', "in a long listing, don't print group names")
@@ -131,6 +132,7 @@ func GetConfig() *app.Config {
 	c.NoGroup = *noGroup
 	c.HumanReadable = *humanReadable
 	c.ShowBlockSize = *showBlockSize
+	c.ShowInodeNumber = *showInodeNumber
 
 	args := getopt.Args()
 	if len(args) > 0 {

--- a/format/format.go
+++ b/format/format.go
@@ -3,6 +3,7 @@ package format
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -101,20 +102,33 @@ func GetIndicator(name string, isLongMode bool) (i string) {
 }
 
 func GetHardLinkCount(absPath string) uint64 {
-	// Get file info
 	fileInfo, err := os.Stat(absPath)
 	if err != nil {
 		return 0
 	}
 
-	// Get the underlying stat structure
 	stat, ok := fileInfo.Sys().(*syscall.Stat_t)
 	if !ok {
 		return 0
 	}
 
-	// Return the number of hard links
 	return uint64(stat.Nlink)
+}
+
+func GetInodeNumber(path string) string {
+	fileInfo, err := os.Stat(path)
+
+	if err != nil {
+		return ""
+	}
+
+	stat, ok := fileInfo.Sys().(*syscall.Stat_t)
+
+	if !ok {
+		return ""
+	}
+
+	return strconv.Itoa(int(stat.Ino))
 }
 
 func IsLink(name string) bool {

--- a/model/dir.go
+++ b/model/dir.go
@@ -33,6 +33,7 @@ type Entry struct {
 	GitStatus            string
 	Icon                 string
 	IconColor            string
+	InodeNumber          string
 }
 
 type Directory struct {


### PR DESCRIPTION
With these changes:

- `-i` can be used to show the inode number of each file listed
- `-I` can be used to disable icons for the output
