### PR TITLE
fix: icon toggle flag and space trim

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -131,7 +131,7 @@ func (a *App) blockSizeWithInode(entry *model.Entry) string {
 		blockSize = fmt.Sprintf("%s %s", entry.InodeNumber, blockSize)
 	}
 
-	return blockSize
+	return strings.TrimSpace(blockSize)
 }
 
 func (a *App) Print(d *model.Directory) {
@@ -149,7 +149,7 @@ func (a *App) Print(d *model.Directory) {
 			lineCtw.AddRow(
 				a.blockSizeWithInode(v),
 				v.Mode,
-				fmt.Sprintf(" %v", strconv.Itoa(int(v.NumHardLinks))),
+				fmt.Sprintf("%v", strconv.Itoa(int(v.NumHardLinks))),
 				v.Owner,
 				v.Group,
 				a.getFormattedSize(v.Size),

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -39,7 +39,7 @@ func GetConfig() *app.Config {
 	recursive := getopt.BoolLong("recursive", 'R', "list subdirectories recursively")
 	gitStatus := getopt.BoolLong("git-status", 'D', "print git status of files")
 	disableColor := getopt.BoolLong("disable-color", 'c', "don't color icons, filenames and git status (use this to print to a file)")
-	disableIcon := getopt.BoolLong("disable-icon", 'I', "don't print icons of the files")
+	disableIcon := getopt.BoolLong("disable-icon", 'e', "don't print icons of the files")
 	showInodeNumber := getopt.BoolLong("inode", 'i', "print the index number of each file")
 	oneFilePerLine := getopt.Bool('1', "list one file per line.")
 	directory := getopt.BoolLong("directory", 'd', "list directories themselves, not their contents")


### PR DESCRIPTION
To avoid clashes with original ls flags now `-e` is used to toggle icons. Moreover, duplicated space issues have ben fixed in long mode.
