### PR TITLE
feat: right alignment in long mode

### DIFF
--- a/ctw/long_ctw.go
+++ b/ctw/long_ctw.go
@@ -70,8 +70,10 @@ func (l *LongCTW) Flush(buf *bytes.Buffer) {
 			} else if j >= l.cols-1 && (1<<l.cols)&skipCol == 0 {
 				color := l.GetGitColor(r[l.cols])
 				fmt.Fprintf(buf, "%s%-*s%s", color, l.c[j], c, l.noColor)
-			} else {
+			} else if (1<<l.cols)&skipCol > 0 && j == l.cols-1 {
 				fmt.Fprintf(buf, "%-*s", l.c[j], c)
+			} else {
+				fmt.Fprintf(buf, "%*s", l.c[j], c)
 			}
 			f = false
 		}


### PR DESCRIPTION
Now the columns of the long mode output are all right-aligned except for the last one containing icon, file name and eventual git status.
