### PR TITLE
Fix/format

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -153,7 +153,7 @@ func (a *App) Print(d *model.Directory) {
 				v.Owner,
 				v.Group,
 				a.getFormattedSize(v.Size),
-				v.ModTime.Format(a.Config.TimeFormat),
+				a.Config.TimeFormatter.Format(&v.ModTime),
 				v.Icon,
 				v.Name+v.Ext+v.Indicator,
 				v.GitStatus)
@@ -495,7 +495,6 @@ func (a *App) Run() {
 }
 
 func (a *App) getFormattedSize(b int64) string {
-
 	if !a.Config.HumanReadable {
 		return fmt.Sprintf("%d", b)
 	}
@@ -510,6 +509,14 @@ func (a *App) getFormattedSize(b int64) string {
 		div *= unit
 		exp++
 	}
-	return fmt.Sprintf("%.1f%c",
-		float64(b)/float64(div), "KMGTPE"[exp])
+
+	size := float64(b) / float64(div)
+
+	// Check if the size is a whole number
+	if size == float64(int64(size)) {
+		return fmt.Sprintf("%d%c", int64(size), "KMGTPE"[exp])
+	}
+
+	// Otherwise, keep one decimal place
+	return fmt.Sprintf("%.1f%c", size, "KMGTPE"[exp])
 }

--- a/app/app.go
+++ b/app/app.go
@@ -118,7 +118,7 @@ func (a *App) GetCtw() ctw.CTW {
 
 func (a *App) getBlockSize(block int64) string {
 	if a.Config.ShowBlockSize {
-		return a.getFormattedSize(block)
+		return format.GetFormattedSize(block, a.Config.HumanReadable)
 	}
 
 	return ""
@@ -152,7 +152,7 @@ func (a *App) Print(d *model.Directory) {
 				fmt.Sprintf("%v", strconv.Itoa(int(v.NumHardLinks))),
 				v.Owner,
 				v.Group,
-				a.getFormattedSize(v.Size),
+				format.GetFormattedSize(v.Size, a.Config.HumanReadable),
 				a.Config.TimeFormatter.Format(&v.ModTime),
 				v.Icon,
 				v.Name+v.Ext+v.Indicator,
@@ -492,31 +492,4 @@ func (a *App) Run() {
 			}
 		}
 	}
-}
-
-func (a *App) getFormattedSize(b int64) string {
-	if !a.Config.HumanReadable {
-		return fmt.Sprintf("%d", b)
-	}
-
-	const unit = 1024
-	if b < unit {
-		return fmt.Sprintf("%d", b)
-	}
-
-	div, exp := int64(unit), 0
-	for n := b / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-
-	size := float64(b) / float64(div)
-
-	// Check if the size is a whole number
-	if size == float64(int64(size)) {
-		return fmt.Sprintf("%d%c", int64(size), "KMGTPE"[exp])
-	}
-
-	// Otherwise, keep one decimal place
-	return fmt.Sprintf("%.1f%c", size, "KMGTPE"[exp])
 }

--- a/app/config.go
+++ b/app/config.go
@@ -1,8 +1,7 @@
 package app
 
 import (
-	"time"
-
+	"github.com/canta2899/logo-ls/format"
 	"github.com/canta2899/logo-ls/model"
 )
 
@@ -11,7 +10,7 @@ type Config struct {
 	AllMode         model.Include
 	SortMode        model.SortMode
 	LongListingMode model.Listing
-	TimeFormat      string
+	TimeFormatter   format.Timestamp
 	Recursive       bool
 	GitStatus       bool
 	Reverse         bool
@@ -44,7 +43,7 @@ func NewConfig() *Config {
 		ShowBlockSize:   false,
 		ShowInodeNumber: false,
 		TerminalWidth:   80,
-		TimeFormat:      time.Stamp,
+		TimeFormatter:   nil,
 		FileList:        []string{},
 	}
 }

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"time"
 
 	"github.com/canta2899/logo-ls/app"
+	"github.com/canta2899/logo-ls/format"
 	"github.com/canta2899/logo-ls/model"
 	"github.com/pborman/getopt/v2"
 	"golang.org/x/term"
@@ -47,26 +47,7 @@ func GetConfig() *app.Config {
 	humanReadable := getopt.BoolLong("human-readable", 'h', "with -l and -s, print sizes like 1K 234M 2G etc.")
 	showBlockSize := getopt.BoolLong("size", 's', "print the allocated size of each file, in blocks")
 
-	timeFormat := getopt.EnumLong(
-		"time-style",
-		'T',
-		[]string{
-			"Stamp",
-			"StampMilli",
-			"Kitchen",
-			"ANSIC",
-			"UnixDate",
-			"RubyDate",
-			"RFC1123",
-			"RFC1123Z",
-			"RFC3339",
-			"RFC822",
-			"RFC822Z",
-			"RFC850",
-		},
-		"Stamp",
-		"time/date format with -l; see time-style below",
-	)
+	completeTimeInformation := getopt.BoolLong("time-style", 'T', "display complete time information")
 
 	c.LongListingMode = model.LongListingNone
 
@@ -120,7 +101,7 @@ func GetConfig() *app.Config {
 		c.LongListingMode = model.LongListingDefault
 	}
 
-	c.TimeFormat = toTimeFormat(*timeFormat)
+	c.TimeFormatter = format.GetFormatter(*completeTimeInformation)
 
 	c.Reverse = *reverse
 	c.Recursive = *recursive
@@ -150,40 +131,8 @@ func GetConfig() *app.Config {
 	return c
 }
 
-func toTimeFormat(tf string) string {
-	switch tf {
-	case "Stamp":
-		return time.Stamp
-	case "StampMilli":
-		return time.StampMilli
-	case "Kitchen":
-		return time.Kitchen
-	case "ANSIC":
-		return time.ANSIC
-	case "UnixDate":
-		return time.UnixDate
-	case "RubyDate":
-		return time.RubyDate
-	case "RFC1123":
-		return time.RFC1123
-	case "RFC1123Z":
-		return time.RFC1123Z
-	case "RFC3339":
-		return time.RFC3339
-	case "RFC822":
-		return time.RFC822
-	case "RFC822Z":
-		return time.RFC822Z
-	case "RFC850":
-		return time.RFC850
-	default:
-		return time.Stamp
-	}
-}
-
 func printVersion() {
-	fmt.Printf("logo-ls %s\nCopyright (c) 2020 Yash Handa\nLicense MIT <https://opensource.org/licenses/MIT>.\nThis is free software: you are free to change and redistribute it.\nThere is NO WARRANTY, to the extent permitted by law.\n", "v1.3.7")
-	fmt.Println("\nWritten by Yash Handa")
+	fmt.Printf("logo-ls %s\nLicense MIT <https://opensource.org/licenses/MIT>.\nThis is free software: you are free to change and redistribute it.\nThere is NO WARRANTY, to the extent permitted by law.\n", "v1.3.7")
 }
 
 func printHelpMessage() {

--- a/format/format.go
+++ b/format/format.go
@@ -1,6 +1,7 @@
 package format
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -211,4 +212,31 @@ func GetIcon(name, ext, indicator string) (icon, color string) {
 	}
 
 	return i.GetGlyph(), i.GetColor(1)
+}
+
+func GetFormattedSize(b int64, humanReadable bool) string {
+	if humanReadable {
+		return fmt.Sprintf("%d", b)
+	}
+
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d", b)
+	}
+
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+
+	size := float64(b) / float64(div)
+
+	// Check if the size is a whole number
+	if size == float64(int64(size)) {
+		return fmt.Sprintf("%d%c", int64(size), "KMGTPE"[exp])
+	}
+
+	// Otherwise, keep one decimal place
+	return fmt.Sprintf("%.1f%c", size, "KMGTPE"[exp])
 }

--- a/format/timestamp.go
+++ b/format/timestamp.go
@@ -1,0 +1,30 @@
+package format
+
+import "time"
+
+type Timestamp interface {
+	Format(t *time.Time) string
+}
+
+type DefaultFormatter struct{}
+type ExtendedFormatter struct{}
+
+func (*DefaultFormatter) Format(t *time.Time) string {
+	if t.Year() != time.Now().Year() {
+		return t.Format("Jan 02 15:04")
+	}
+
+	return t.Format("Jan 02  2006")
+}
+
+func (*ExtendedFormatter) Format(t *time.Time) string {
+	return t.Format("Jan 02 15:04:05 2006")
+}
+
+func GetFormatter(extended bool) Timestamp {
+	if extended {
+		return &ExtendedFormatter{}
+	}
+
+	return &DefaultFormatter{}
+}

--- a/format/timestamp.go
+++ b/format/timestamp.go
@@ -10,7 +10,7 @@ type DefaultFormatter struct{}
 type ExtendedFormatter struct{}
 
 func (*DefaultFormatter) Format(t *time.Time) string {
-	if t.Year() != time.Now().Year() {
+	if t.Year() == time.Now().Year() {
 		return t.Format("Jan 02 15:04")
 	}
 


### PR DESCRIPTION
Removed `-T [format name]` flag in favour of `-T` that, in long mode, will format dates as  `Jan 02 15:04:05 2006`. Otherwise, the default format depends on how old the file is and can be either `Jan 02 15:04` for files updated in the current year or `Jan 02  2006` for files updated in a different year. This behaviour reproduces the one of ls(coreutils).