### PR TITLE
fix: group files with no extension first when using -X

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -92,11 +92,20 @@ func SetLessFunction(d *model.Directory, sortMode model.SortMode) {
 	case model.SortExtension:
 		// sort alphabetically by entry extension
 		d.LessFn = func(i, j int) bool {
+			// dotfiles first
 			a := d.Files[i].Name + d.Files[i].Ext
 			b := d.Files[j].Name + d.Files[j].Ext
 			if res, ok := DotFileOrder(a, b); ok {
 				return res
 			}
+			// directories and files with no extension second
+			if d.Files[i].Ext == "" && d.Files[j].Ext != "" {
+				return true
+			}
+			if d.Files[i].Ext != "" && d.Files[j].Ext == "" {
+				return false
+			}
+			// then, all the rest
 			if MainSort(d.Files[i].Ext, d.Files[j].Ext) {
 				return true
 			} else if strings.EqualFold(d.Files[i].Ext, d.Files[j].Ext) {


### PR DESCRIPTION
Before https://github.com/canta2899/logo-ls/commit/f8bf8709ec698a31d31e12e325b67f62563e2bd5, `logo-ls -X` had the nice property of grouping directories/files with no extension first, exactly like coreutils `ls -X`.
This brings back that behavior, while still keeping dotfiles first when `-X` is used in combination with `-a` or `-A`.

#### Explanation

Consider for instance the comparison "src" vs "README.md".
Before f8bf8709ec698a31d31e12e325b67f62563e2bd5, we would first go through https://github.com/canta2899/logo-ls/blob/e9f201d77c33efd3e7c67a672d39973e9c4b2380/format/format.go#L55 and this would return `true` thanks to https://github.com/canta2899/logo-ls/blob/e9f201d77c33efd3e7c67a672d39973e9c4b2380/format/format.go#L24 comparing `""` to `"md"`.

After f8bf8709ec698a31d31e12e325b67f62563e2bd5, the same call to `MainSort` would end up returning `false`, as we would end up here
https://github.com/canta2899/logo-ls/blob/10caa3d5218cb8d2125c647106d596782dcdbfa4/format/format.go#L30