### PR TITLE
fix: adapted sorting to LC_COLLATE

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -125,8 +125,13 @@ func SetLessFunction(d *model.Directory, sortMode model.SortMode) {
 			if ra != rb {
 				return ra < rb
 			}
-			if ra == 2 && !strings.EqualFold(d.Files[i].Ext, d.Files[j].Ext) {
-				return compareName(d.Files[i].Ext, d.Files[j].Ext)
+			if ra == 2 {
+				if compareName(d.Files[i].Ext, d.Files[j].Ext) {
+					return true
+				}
+				if compareName(d.Files[j].Ext, d.Files[i].Ext) {
+					return false
+				}
 			}
 			return MainSort(a, b)
 		}

--- a/format/format.go
+++ b/format/format.go
@@ -39,31 +39,20 @@ func cLocaleCollation() bool {
 	return loc == "" || loc == "C" || loc == "POSIX"
 }
 
-// sortExtKey returns the extension sort key used by -X, matching GNU ls: a
-// dotfile's extension is everything after its leading dot. Returns "" for
-// names with no extension (LICENSE, Makefile, dirs, "." and "..").
-func sortExtKey(name, ext string) string {
-	if ext != "" {
-		return strings.ToLower(strings.TrimPrefix(ext, "."))
+// extGroupRank ranks an entry for -X (sort by extension) into one of three
+// contiguous groups: 0 = extensionless non-dotfiles (dirs, LICENSE, Makefile),
+// 1 = dotfiles (kept grouped, incl. "." and ".."), 2 = files with an extension.
+func extGroupRank(name, ext string) int {
+	if strings.HasPrefix(name, ".") {
+		return 1
 	}
-	if strings.HasPrefix(name, ".") && name != "." && name != ".." {
-		return strings.ToLower(name[1:])
+	if ext == "" {
+		return 0
 	}
-	return ""
+	return 2
 }
 
 func MainSort(a, b string) bool {
-	// "." and ".." always come first
-	if a == "." || a == ".." {
-		if b == "." || b == ".." {
-			return a < b
-		}
-		return true
-	}
-	if b == "." || b == ".." {
-		return false
-	}
-
 	aDot := strings.HasPrefix(a, ".")
 	bDot := strings.HasPrefix(b, ".")
 
@@ -84,15 +73,9 @@ func MainSort(a, b string) bool {
 
 // DotFileOrder checks whether dotfile grouping determines the order.
 // Returns (result, decided): if decided is true, use result as the less value.
+// "." and ".." are ordinary dotfiles here, sorted within the dotfile group by
+// the caller's comparison rather than force-pinned to the top.
 func DotFileOrder(a, b string) (bool, bool) {
-	aSpecial := a == "." || a == ".."
-	bSpecial := b == "." || b == ".."
-	if aSpecial || bSpecial {
-		if aSpecial && bSpecial {
-			return a < b, true
-		}
-		return aSpecial, true
-	}
 	aDot := strings.HasPrefix(a, ".")
 	bDot := strings.HasPrefix(b, ".")
 	if aDot != bDot {
@@ -131,26 +114,21 @@ func SetLessFunction(d *model.Directory, sortMode model.SortMode) {
 			return d.Files[i].ModTime.After(d.Files[j].ModTime)
 		}
 	case model.SortExtension:
-		// sort alphabetically by entry extension; dotfiles sort into their
-		// natural extension group (GNU ls behaviour), not forced to the top
+		// extensionless files/dirs first, then dotfiles (kept grouped), then
+		// files sorted by extension. "." and ".." are ordinary dotfiles, sorted
+		// within the dotfile group rather than force-pinned to the top.
 		d.LessFn = func(i, j int) bool {
 			a := d.Files[i].Name + d.Files[i].Ext
 			b := d.Files[j].Name + d.Files[j].Ext
-			// "." and ".." always come first
-			aSpecial := a == "." || a == ".."
-			bSpecial := b == "." || b == ".."
-			if aSpecial || bSpecial {
-				if aSpecial && bSpecial {
-					return a < b
-				}
-				return aSpecial
+			ra := extGroupRank(d.Files[i].Name, d.Files[i].Ext)
+			rb := extGroupRank(d.Files[j].Name, d.Files[j].Ext)
+			if ra != rb {
+				return ra < rb
 			}
-			extA := sortExtKey(d.Files[i].Name, d.Files[i].Ext)
-			extB := sortExtKey(d.Files[j].Name, d.Files[j].Ext)
-			if extA != extB {
-				return extA < extB
+			if ra == 2 && !strings.EqualFold(d.Files[i].Ext, d.Files[j].Ext) {
+				return compareName(d.Files[i].Ext, d.Files[j].Ext)
 			}
-			return compareName(a, b)
+			return MainSort(a, b)
 		}
 	case model.SortNatural:
 		// natural sort of (version) numbers within text

--- a/format/format.go
+++ b/format/format.go
@@ -11,10 +11,10 @@ import (
 )
 
 // compareName orders two names the way system ls does, honouring the active
-// collation locale (LC_ALL → LC_COLLATE → LANG, read at call time). In the
+// collation locale (LC_ALL -> LC_COLLATE -> LANG, read at call time). In the
 // C/POSIX locale, comparison is by byte/ASCII order (uppercase before
 // lowercase); in any other locale it falls back to case-insensitive order,
-// matching the en_US.UTF-8 behaviour common on desktops.
+// matching the en_US.UTF-8 behaviour
 func compareName(a, b string) bool {
 	if cLocaleCollation() {
 		return a < b
@@ -37,6 +37,19 @@ func cLocaleCollation() bool {
 		loc = loc[:i]
 	}
 	return loc == "" || loc == "C" || loc == "POSIX"
+}
+
+// sortExtKey returns the extension sort key used by -X, matching GNU ls: a
+// dotfile's extension is everything after its leading dot. Returns "" for
+// names with no extension (LICENSE, Makefile, dirs, "." and "..").
+func sortExtKey(name, ext string) string {
+	if ext != "" {
+		return strings.ToLower(strings.TrimPrefix(ext, "."))
+	}
+	if strings.HasPrefix(name, ".") && name != "." && name != ".." {
+		return strings.ToLower(name[1:])
+	}
+	return ""
 }
 
 func MainSort(a, b string) bool {
@@ -118,29 +131,26 @@ func SetLessFunction(d *model.Directory, sortMode model.SortMode) {
 			return d.Files[i].ModTime.After(d.Files[j].ModTime)
 		}
 	case model.SortExtension:
-		// sort alphabetically by entry extension
+		// sort alphabetically by entry extension; dotfiles sort into their
+		// natural extension group (GNU ls behaviour), not forced to the top
 		d.LessFn = func(i, j int) bool {
-			// dotfiles first
 			a := d.Files[i].Name + d.Files[i].Ext
 			b := d.Files[j].Name + d.Files[j].Ext
-			if res, ok := DotFileOrder(a, b); ok {
-				return res
+			// "." and ".." always come first
+			aSpecial := a == "." || a == ".."
+			bSpecial := b == "." || b == ".."
+			if aSpecial || bSpecial {
+				if aSpecial && bSpecial {
+					return a < b
+				}
+				return aSpecial
 			}
-			// directories and files with no extension second
-			if d.Files[i].Ext == "" && d.Files[j].Ext != "" {
-				return true
+			extA := sortExtKey(d.Files[i].Name, d.Files[i].Ext)
+			extB := sortExtKey(d.Files[j].Name, d.Files[j].Ext)
+			if extA != extB {
+				return extA < extB
 			}
-			if d.Files[i].Ext != "" && d.Files[j].Ext == "" {
-				return false
-			}
-			// then, all the rest
-			if MainSort(d.Files[i].Ext, d.Files[j].Ext) {
-				return true
-			} else if strings.EqualFold(d.Files[i].Ext, d.Files[j].Ext) {
-				return MainSort(a, b)
-			} else {
-				return false
-			}
+			return compareName(a, b)
 		}
 	case model.SortNatural:
 		// natural sort of (version) numbers within text

--- a/format/format.go
+++ b/format/format.go
@@ -3,11 +3,41 @@ package format
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/canta2899/logo-ls/icons"
 	"github.com/canta2899/logo-ls/model"
 )
+
+// compareName orders two names the way system ls does, honouring the active
+// collation locale (LC_ALL → LC_COLLATE → LANG, read at call time). In the
+// C/POSIX locale, comparison is by byte/ASCII order (uppercase before
+// lowercase); in any other locale it falls back to case-insensitive order,
+// matching the en_US.UTF-8 behaviour common on desktops.
+func compareName(a, b string) bool {
+	if cLocaleCollation() {
+		return a < b
+	}
+	return strings.ToLower(a) < strings.ToLower(b)
+}
+
+// cLocaleCollation reports whether the effective collation locale is the
+// C/POSIX locale (or unset), in which case byte-order comparison applies.
+func cLocaleCollation() bool {
+	loc := ""
+	for _, k := range []string{"LC_ALL", "LC_COLLATE", "LANG"} {
+		if v := os.Getenv(k); v != "" {
+			loc = v
+			break
+		}
+	}
+	// Strip any codeset suffix, e.g. "C.UTF-8" → "C".
+	if i := strings.IndexByte(loc, '.'); i >= 0 {
+		loc = loc[:i]
+	}
+	return loc == "" || loc == "C" || loc == "POSIX"
+}
 
 func MainSort(a, b string) bool {
 	// "." and ".." always come first
@@ -36,7 +66,7 @@ func MainSort(a, b string) bool {
 	if bDot {
 		b = strings.TrimPrefix(b, ".")
 	}
-	return strings.ToLower(a) < strings.ToLower(b)
+	return compareName(a, b)
 }
 
 // DotFileOrder checks whether dotfile grouping determines the order.

--- a/tests/e2e_perflag_test.go
+++ b/tests/e2e_perflag_test.go
@@ -202,7 +202,9 @@ func TestFlag_X_SortByExtension(t *testing.T) {
 	r := runApp(t, vfs, "-1Xe", "/root")
 	assertGolden(t, "flag_X", r.Stdout)
 	assertExitCode(t, model.CodeOk, r.ExitCode)
-	// Intent: -X puts files with no extension first, then .go, then .md.
+	// Intent: -X puts no-extension files first (Makefile, script), then .go,
+	// then .md. mixedExtTree has no dotfiles, so the dotfile-by-extension
+	// behaviour (covered by TestSort_ExtensionDotfilesByExt) does not apply here.
 	got := lines(r.Stdout)
 	if len(got) < 5 {
 		t.Fatalf("expected 5 entries, got %v", got)

--- a/tests/e2e_sort_test.go
+++ b/tests/e2e_sort_test.go
@@ -56,12 +56,12 @@ func TestSort_AllModesAreDistinct(t *testing.T) {
 
 func TestSort_DotfilesAlwaysFirst(t *testing.T) {
 	// For sort modes that apply dotfile grouping (alphabetical, size,
-	// extension, natural), .hidden must lead. Mtime sort and -U intentionally
-	// do not regroup dotfiles, so they are excluded here.
+	// natural), .hidden must lead. Mtime sort and -U intentionally do not
+	// regroup dotfiles; -X (extension) sorts dotfiles into their natural
+	// extension group rather than forcing them first, so all are excluded here.
 	for _, args := range [][]string{
 		{"-1Ae", "/root"},
 		{"-1ASe", "/root"},
-		{"-1AXe", "/root"},
 		{"-1Ave", "/root"},
 	} {
 		vfs := fakefs.New(sortFixture())
@@ -70,6 +70,24 @@ func TestSort_DotfilesAlwaysFirst(t *testing.T) {
 		if len(got) == 0 || got[0] != ".hidden" {
 			t.Errorf("args %v: expected .hidden first, got %v", args, got)
 		}
+	}
+}
+
+func TestSort_ExtensionDotfilesByExt(t *testing.T) {
+	// With -X, dotfiles sort into their extension group (the name after the
+	// leading dot), matching GNU ls, rather than being forced to the top.
+	vfs := fakefs.New(dotfileExtTree())
+	r := runApp(t, vfs, "-1AXe", "/root")
+	assertExitCode(t, model.CodeOk, r.ExitCode)
+	got := lines(r.Stdout)
+	// Key order: "" (Makefile) < "go" (a.go) < "hidden" (.hidden) < "md" (README.md).
+	want := []string{"Makefile", "a.go", ".hidden", "README.md"}
+	if !equalSlice(got, want) {
+		t.Errorf("-AX order:\nwant %v\ngot  %v", want, got)
+	}
+	// .hidden must not lead: no-extension files come before it ("" < "hidden").
+	if got[0] == ".hidden" {
+		t.Errorf("expected .hidden to sort into its extension group, not first: %v", got)
 	}
 }
 

--- a/tests/e2e_sort_test.go
+++ b/tests/e2e_sort_test.go
@@ -13,6 +13,11 @@ import (
 // output, the fixture is too tame and we should change it.
 
 func TestSort_AlphabeticalIsDefault(t *testing.T) {
+	// Pin to the C locale so collation is deterministic across systems
+	// (uppercase before lowercase, byte order).
+	t.Setenv("LC_ALL", "")
+	t.Setenv("LC_COLLATE", "C")
+	t.Setenv("LANG", "")
 	vfs := fakefs.New(sortFixture())
 	r := runApp(t, vfs, "-1e", "/root")
 	assertGolden(t, "sort_alphabetical", r.Stdout)

--- a/tests/e2e_sort_test.go
+++ b/tests/e2e_sort_test.go
@@ -57,8 +57,8 @@ func TestSort_AllModesAreDistinct(t *testing.T) {
 func TestSort_DotfilesAlwaysFirst(t *testing.T) {
 	// For sort modes that apply dotfile grouping (alphabetical, size,
 	// natural), .hidden must lead. Mtime sort and -U intentionally do not
-	// regroup dotfiles; -X (extension) sorts dotfiles into their natural
-	// extension group rather than forcing them first, so all are excluded here.
+	// regroup dotfiles; -X groups dotfiles after extensionless files (not
+	// necessarily first), so all of these are excluded here.
 	for _, args := range [][]string{
 		{"-1Ae", "/root"},
 		{"-1ASe", "/root"},
@@ -74,20 +74,49 @@ func TestSort_DotfilesAlwaysFirst(t *testing.T) {
 }
 
 func TestSort_ExtensionDotfilesByExt(t *testing.T) {
-	// With -X, dotfiles sort into their extension group (the name after the
-	// leading dot), matching GNU ls, rather than being forced to the top.
+	// With -X, dotfiles stay grouped: extensionless non-dotfiles first, then
+	// the dotfile group, then files sorted by extension. Dotfiles are neither
+	// interleaved by extension nor force-pinned to the top.
 	vfs := fakefs.New(dotfileExtTree())
 	r := runApp(t, vfs, "-1AXe", "/root")
 	assertExitCode(t, model.CodeOk, r.ExitCode)
 	got := lines(r.Stdout)
-	// Key order: "" (Makefile) < "go" (a.go) < "hidden" (.hidden) < "md" (README.md).
-	want := []string{"Makefile", "a.go", ".hidden", "README.md"}
+	// Makefile (no ext), then .hidden (dotfile group), then a.go, README.md.
+	want := []string{"Makefile", ".hidden", "a.go", "README.md"}
 	if !equalSlice(got, want) {
 		t.Errorf("-AX order:\nwant %v\ngot  %v", want, got)
 	}
-	// .hidden must not lead: no-extension files come before it ("" < "hidden").
+	// .hidden must not lead: extensionless non-dotfiles come first.
 	if got[0] == ".hidden" {
-		t.Errorf("expected .hidden to sort into its extension group, not first: %v", got)
+		t.Errorf("expected extensionless files before the dotfile group: %v", got)
+	}
+}
+
+func TestSort_ExtensionDotfilesStayGrouped(t *testing.T) {
+	// -X groups dotfiles together as a contiguous block: extensionless
+	// non-dotfiles (dirs, Makefile) first, then every dotfile (including
+	// ".config.json", which must NOT sort among the regular .json files), then
+	// the remaining files by extension. "." and ".." are ordinary dotfiles and
+	// sort within the dotfile group, not force-pinned to the very top.
+	t.Setenv("LC_ALL", "")
+	t.Setenv("LC_COLLATE", "C")
+	t.Setenv("LANG", "")
+	vfs := fakefs.New(dotfileGroupTree())
+	r := runApp(t, vfs, "-1aXe", "/root")
+	assertExitCode(t, model.CodeOk, r.ExitCode)
+	got := lines(r.Stdout)
+
+	want := []string{
+		"Makefile", "src/", // extensionless non-dotfiles
+		"./", "../", ".config.json", ".hidden", // dotfile group
+		"main.go", "app.json", // by extension: go < json
+	}
+	if !equalSlice(got, want) {
+		t.Fatalf("-aX grouping:\nwant %v\ngot  %v", want, got)
+	}
+	// "." / ".." must not be force-pinned: extensionless files lead.
+	if got[0] == "./" || got[0] == "../" {
+		t.Errorf("expected extensionless files before . and .., got %v", got)
 	}
 }
 

--- a/tests/fixtures_test.go
+++ b/tests/fixtures_test.go
@@ -156,6 +156,19 @@ func mixedExtTree() *fakefs.Entry {
 	)
 }
 
+// dotfileExtTree: dotfiles mixed with regular and extension-less files, used
+// to verify that -X sorts dotfiles into their natural extension group instead
+// of forcing them to the top. Expected -X key order: "" (Makefile), "go"
+// (a.go), "hidden" (.hidden), "md" (README.md).
+func dotfileExtTree() *fakefs.Entry {
+	return fakefs.Dir("root", dirMeta("9000"),
+		fakefs.File(".hidden", 1, mtime("2026-01-01 00:00:00"), fileMeta("9001")),
+		fakefs.File("Makefile", 200, mtime("2026-03-01 10:00:00"), fileMeta("9002")),
+		fakefs.File("README.md", 10, mtime("2026-02-01 10:00:00"), fileMeta("9003")),
+		fakefs.File("a.go", 50, mtime("2026-01-20 10:00:00"), fileMeta("9004")),
+	)
+}
+
 // execTree: a single executable file to exercise the '*' indicator.
 func execTree() *fakefs.Entry {
 	return fakefs.Dir("root", dirMeta("8000"),

--- a/tests/fixtures_test.go
+++ b/tests/fixtures_test.go
@@ -157,15 +157,30 @@ func mixedExtTree() *fakefs.Entry {
 }
 
 // dotfileExtTree: dotfiles mixed with regular and extension-less files, used
-// to verify that -X sorts dotfiles into their natural extension group instead
-// of forcing them to the top. Expected -X key order: "" (Makefile), "go"
-// (a.go), "hidden" (.hidden), "md" (README.md).
+// to verify that -X keeps dotfiles grouped. Expected -X order: Makefile
+// (no ext), .hidden (dotfile group), a.go, README.md (by extension).
 func dotfileExtTree() *fakefs.Entry {
 	return fakefs.Dir("root", dirMeta("9000"),
 		fakefs.File(".hidden", 1, mtime("2026-01-01 00:00:00"), fileMeta("9001")),
 		fakefs.File("Makefile", 200, mtime("2026-03-01 10:00:00"), fileMeta("9002")),
 		fakefs.File("README.md", 10, mtime("2026-02-01 10:00:00"), fileMeta("9003")),
 		fakefs.File("a.go", 50, mtime("2026-01-20 10:00:00"), fileMeta("9004")),
+	)
+}
+
+// dotfileGroupTree: a directory plus extensionless, dotfile (with and without
+// an extension) and regular extension entries. Used to verify that -X keeps the
+// whole dotfile group together (incl. a dotfile that *has* an extension, which
+// must not sort among the regular extension files) and that "." / ".." are not
+// force-pinned to the top.
+func dotfileGroupTree() *fakefs.Entry {
+	return fakefs.Dir("root", dirMeta("9100"),
+		fakefs.Dir("src", dirMeta("9101")),
+		fakefs.File("Makefile", 200, mtime("2026-03-01 10:00:00"), fileMeta("9102")),
+		fakefs.File(".hidden", 1, mtime("2026-01-01 00:00:00"), fileMeta("9103")),
+		fakefs.File(".config.json", 30, mtime("2026-01-02 00:00:00"), fileMeta("9104")),
+		fakefs.File("main.go", 50, mtime("2026-01-20 10:00:00"), fileMeta("9105")),
+		fakefs.File("app.json", 40, mtime("2026-01-21 10:00:00"), fileMeta("9106")),
 	)
 }
 

--- a/tests/harness_test.go
+++ b/tests/harness_test.go
@@ -20,6 +20,17 @@ import (
 
 var updateGolden = flag.Bool("update", false, "regenerate golden files")
 
+// TestMain pins the collation locale to C for the whole suite so name sorting
+// is deterministic regardless of the host's locale. logo-ls sorts names via
+// the active LC_COLLATE (matching system ls), so without this the goldens
+// would drift between C and UTF-8 environments.
+func TestMain(m *testing.M) {
+	os.Setenv("LC_ALL", "C")
+	os.Setenv("LC_COLLATE", "C")
+	os.Setenv("LANG", "C")
+	os.Exit(m.Run())
+}
+
 // fixedTime is a deterministic time formatter. It ignores time.Now() so
 // goldens don't drift over the years.
 type fixedTime struct{}

--- a/tests/testdata/args_file_and_dir.txt
+++ b/tests/testdata/args_file_and_dir.txt
@@ -1,5 +1,5 @@
 README.md
 
-notes.txt
 README.md
+notes.txt
 src/

--- a/tests/testdata/combo_default_columns.txt
+++ b/tests/testdata/combo_default_columns.txt
@@ -1,1 +1,1 @@
-notes.txt  README.md  src/
+README.md  notes.txt  src/

--- a/tests/testdata/combo_li.txt
+++ b/tests/testdata/combo_li.txt
@@ -1,3 +1,3 @@
-1002 -rw-r--r--  1 alice  staff    256 2026-01-10 09:00 notes.txt
 1001 -rw-r--r--  1 alice  staff   1234 2026-01-15 10:00 README.md
+1002 -rw-r--r--  1 alice  staff    256 2026-01-10 09:00 notes.txt
 1003 drwxr-xr-x  2 alice  staff      0 2026-01-01 00:00 src/

--- a/tests/testdata/combo_ls.txt
+++ b/tests/testdata/combo_ls.txt
@@ -1,3 +1,3 @@
-8 -rw-r--r--  1 alice  staff    256 2026-01-10 09:00 notes.txt
 8 -rw-r--r--  1 alice  staff   1234 2026-01-15 10:00 README.md
+8 -rw-r--r--  1 alice  staff    256 2026-01-10 09:00 notes.txt
 0 drwxr-xr-x  2 alice  staff      0 2026-01-01 00:00 src/

--- a/tests/testdata/flag_1.txt
+++ b/tests/testdata/flag_1.txt
@@ -1,3 +1,3 @@
-notes.txt
 README.md
+notes.txt
 src/

--- a/tests/testdata/flag_G_nogroup.txt
+++ b/tests/testdata/flag_G_nogroup.txt
@@ -1,3 +1,3 @@
--rw-r--r--  1 alice  256 2026-01-10 09:00 notes.txt
 -rw-r--r--  1 alice 1234 2026-01-15 10:00 README.md
+-rw-r--r--  1 alice  256 2026-01-10 09:00 notes.txt
 drwxr-xr-x  2 alice    0 2026-01-01 00:00 src/

--- a/tests/testdata/flag_T_timestyle.txt
+++ b/tests/testdata/flag_T_timestyle.txt
@@ -1,3 +1,3 @@
--rw-r--r--  1 alice  staff    256 2026-01-10 09:00 notes.txt
 -rw-r--r--  1 alice  staff   1234 2026-01-15 10:00 README.md
+-rw-r--r--  1 alice  staff    256 2026-01-10 09:00 notes.txt
 drwxr-xr-x  2 alice  staff      0 2026-01-01 00:00 src/

--- a/tests/testdata/flag_e.txt
+++ b/tests/testdata/flag_e.txt
@@ -1,3 +1,3 @@
-notes.txt
 README.md
+notes.txt
 src/

--- a/tests/testdata/flag_g_grouponly.txt
+++ b/tests/testdata/flag_g_grouponly.txt
@@ -1,3 +1,3 @@
--rw-r--r--  1  staff    256 2026-01-10 09:00 notes.txt
 -rw-r--r--  1  staff   1234 2026-01-15 10:00 README.md
+-rw-r--r--  1  staff    256 2026-01-10 09:00 notes.txt
 drwxr-xr-x  2  staff      0 2026-01-01 00:00 src/

--- a/tests/testdata/flag_i.txt
+++ b/tests/testdata/flag_i.txt
@@ -1,1 +1,1 @@
-1002 notes.txt  1001 README.md  1003 src/
+1001 README.md  1002 notes.txt  1003 src/

--- a/tests/testdata/flag_l.txt
+++ b/tests/testdata/flag_l.txt
@@ -1,3 +1,3 @@
--rw-r--r--  1 alice  staff    256 2026-01-10 09:00 notes.txt
 -rw-r--r--  1 alice  staff   1234 2026-01-15 10:00 README.md
+-rw-r--r--  1 alice  staff    256 2026-01-10 09:00 notes.txt
 drwxr-xr-x  2 alice  staff      0 2026-01-01 00:00 src/

--- a/tests/testdata/flag_o.txt
+++ b/tests/testdata/flag_o.txt
@@ -1,3 +1,3 @@
--rw-r--r--  1 alice  256 2026-01-10 09:00 notes.txt
 -rw-r--r--  1 alice 1234 2026-01-15 10:00 README.md
+-rw-r--r--  1 alice  256 2026-01-10 09:00 notes.txt
 drwxr-xr-x  2 alice    0 2026-01-01 00:00 src/

--- a/tests/testdata/flag_r.txt
+++ b/tests/testdata/flag_r.txt
@@ -1,3 +1,3 @@
 src/
-README.md
 notes.txt
+README.md

--- a/tests/testdata/flag_s_blocksize.txt
+++ b/tests/testdata/flag_s_blocksize.txt
@@ -1,1 +1,1 @@
-8 notes.txt  8 README.md  0 src/
+8 README.md  8 notes.txt  0 src/

--- a/tests/testdata/sort_alphabetical.txt
+++ b/tests/testdata/sort_alphabetical.txt
@@ -1,6 +1,6 @@
+Makefile
+README.md
 alpha.txt
 file10.go
 file2.go
-Makefile
-README.md
 zebra.txt


### PR DESCRIPTION
I found out ls(coreutils) sorts according to the `LC_COLLATE` variable and adapted logo-ls to follow the same pattern. Force-pinning . and .. to the top wasn't compliant with real ls anymore (under -r they should drop to the bottom). So I stopped special-casing them. They're just regular dotfiles now and sort naturally.

While in there, I brought back dotfile grouping for -X: extensionless files/dirs first, then the dotfile group, then files by extension. Keeps the nice coreutils-like "extensionless first" property while keeping dotfiles together, which i personally think it's better.