### PR TITLE
refactor: addressed high cyclomatic complexity warnings from sonarqube

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -21,6 +21,8 @@ import (
 	"github.com/canta2899/logo-ls/pkg/fs"
 )
 
+const cannotAccessFmt = "cannot access %q: %v\n"
+
 type App struct {
 	Config   *cli.Config
 	Writer   io.Writer
@@ -77,7 +79,7 @@ func (a *App) GetArguments() *Args {
 
 		f, err := a.FS.Open(abs)
 		if err != nil {
-			a.Logger.Printf("cannot access %q: %v\n", argPath, err)
+			a.Logger.Printf(cannotAccessFmt, argPath, err)
 			a.ExitCode.SetSerious()
 			continue
 		}
@@ -156,7 +158,7 @@ func (a *App) processDirsNonRecursively(dirs []DirectoryEntry) {
 		d, err := a.ProcessDirectory(&dirEntry)
 		dirEntry.Close()
 		if err != nil {
-			a.Logger.Printf("cannot access %q: %v\n", dirEntry.Name(), err)
+			a.Logger.Printf(cannotAccessFmt, dirEntry.Name(), err)
 			a.ExitCode.SetSerious()
 		}
 
@@ -182,7 +184,7 @@ func (a *App) recurseDirectory(start *DirectoryEntry, startingAbsolutePath strin
 		d, err := a.ProcessDirectory(current.entry)
 		current.entry.Close()
 		if err != nil {
-			a.Logger.Printf("cannot access %q: %v\n", current.entry.Name(), err)
+			a.Logger.Printf(cannotAccessFmt, current.entry.Name(), err)
 			a.ExitCode.SetMinor()
 		}
 
@@ -193,30 +195,44 @@ func (a *App) recurseDirectory(start *DirectoryEntry, startingAbsolutePath strin
 		}
 
 		sort.Strings(d.Dirs)
+		stack = a.pushSubdirFrames(stack, current.entry, d.Dirs, startingAbsolutePath)
+	}
+}
 
-		for i := len(d.Dirs) - 1; i >= 0; i-- {
-			subdir := d.Dirs[i]
-			childPath := a.FS.Join(current.entry.Name(), subdir)
-			if rel, err := a.FS.Rel(startingAbsolutePath, childPath); err == nil {
-				childPath = rel
-			}
-
-			subdirFullPath := a.FS.Join(current.entry.Name(), subdir)
-			f, err := a.FS.Open(subdirFullPath)
-			if err != nil {
-				a.Logger.Printf("cannot access %q: %v\n", childPath, err)
-				a.ExitCode.SetMinor()
-				continue
-			}
-			abs, err := a.FS.Abs(subdirFullPath)
-			if err != nil {
-				a.Logger.Println("Cannot compute abs path for:", childPath)
-				f.Close()
-				continue
-			}
-			nextEntry := &DirectoryEntry{File: f, AbsPath: abs}
-			stack = append(stack, &RecursiveLookupFrame{entry: nextEntry, header: childPath})
+func (a *App) pushSubdirFrames(stack []*RecursiveLookupFrame, parent *DirectoryEntry, dirs []string, startingAbsolutePath string) []*RecursiveLookupFrame {
+	for i := len(dirs) - 1; i >= 0; i-- {
+		frame := a.openSubdirFrame(parent, dirs[i], startingAbsolutePath)
+		if frame == nil {
+			continue
 		}
+		stack = append(stack, frame)
+	}
+	return stack
+}
+
+func (a *App) openSubdirFrame(parent *DirectoryEntry, subdir, startingAbsolutePath string) *RecursiveLookupFrame {
+	subdirFullPath := a.FS.Join(parent.Name(), subdir)
+
+	childPath := subdirFullPath
+	if rel, err := a.FS.Rel(startingAbsolutePath, subdirFullPath); err == nil {
+		childPath = rel
+	}
+
+	f, err := a.FS.Open(subdirFullPath)
+	if err != nil {
+		a.Logger.Printf(cannotAccessFmt, childPath, err)
+		a.ExitCode.SetMinor()
+		return nil
+	}
+	abs, err := a.FS.Abs(subdirFullPath)
+	if err != nil {
+		a.Logger.Println("Cannot compute abs path for:", childPath)
+		f.Close()
+		return nil
+	}
+	return &RecursiveLookupFrame{
+		entry:  &DirectoryEntry{File: f, AbsPath: abs},
+		header: childPath,
 	}
 }
 
@@ -250,19 +266,7 @@ func (a *App) populateDirectory(d *DirectoryEntry, dirStat fs.FileInfo) (*Direct
 	t := new(Directory)
 	isLong := a.Config.LongListingMode != cli.LongListingNone
 
-	if a.Config.AllMode == cli.IncludeAll || a.Config.Directory {
-		t.Info = a.buildEntry(d.Name(), dirStat, isLong)
-
-		if !a.Config.Directory {
-			t.Info.Name = "."
-			t.Info.Base = "."
-			t.Info.Ext = ""
-		}
-
-		if !a.Config.DisableIcon {
-			t.Info.Icon = icons.OpenDir()
-		}
-	}
+	a.maybeAttachSelfEntry(t, d, dirStat, isLong)
 
 	if a.Config.Directory {
 		t.Files = append(t.Files, t.Info)
@@ -284,61 +288,88 @@ func (a *App) populateDirectory(d *DirectoryEntry, dirStat fs.FileInfo) (*Direct
 		if !showHidden && strings.HasPrefix(name, ".") {
 			continue
 		}
-
-		fullpath := a.FS.Join(d.Name(), name)
-		fi, infoErr := de.Info() // fi might be nil on error
-		if infoErr != nil {
-			a.Logger.Printf("cannot access %q: %v\n", fullpath, infoErr)
-			a.ExitCode.SetMinor()
-		}
-
-		entry := a.buildEntry(fullpath, fi, isLong)
-
-		if fi == nil {
-			if de.IsDir() {
-				entry.Indicator = "/"
-			} else if de.Type()&iofs.ModeSymlink != 0 {
-				entry.Indicator = "@"
-			}
-			if !a.Config.DisableIcon {
-				entry.Icon = icons.ResolveWith(a.IconOverride, entry.Base, entry.Ext, entry.Indicator)
-			}
-		}
-
-		if gitRepoStatus != nil {
-			entry.GitStatus = gitRepoStatus[name+a.FS.Separator()]
-			if entry.GitStatus == "" {
-				entry.GitStatus = gitRepoStatus[name]
-			}
-		}
-
-		t.Files = append(t.Files, entry)
-		if de.IsDir() {
-			t.Dirs = append(t.Dirs, name+"/")
-		}
+		a.appendChildEntry(t, d, de, gitRepoStatus, isLong)
 	}
 
 	if a.Config.AllMode == cli.IncludeAll {
-		if t.Info != nil {
-			t.Files = append(t.Files, t.Info)
-		}
-
-		pp := a.FS.Dir(d.Name())
-		pStat, _ := a.FS.Lstat(pp)
-
-		parentEntry := a.buildEntry(pp, pStat, isLong)
-		parentEntry.Name = ".."
-		parentEntry.Base = ".."
-		parentEntry.Ext = ""
-
-		if !a.Config.DisableIcon {
-			parentEntry.Icon = icons.OpenDir()
-		}
-
-		t.Files = append(t.Files, parentEntry)
-		t.Parent = parentEntry
+		a.appendDotEntries(t, d, isLong)
 	}
 	return t, err
+}
+
+func (a *App) maybeAttachSelfEntry(t *Directory, d *DirectoryEntry, dirStat fs.FileInfo, isLong bool) {
+	if a.Config.AllMode != cli.IncludeAll && !a.Config.Directory {
+		return
+	}
+	t.Info = a.buildEntry(d.Name(), dirStat, isLong)
+	if !a.Config.Directory {
+		t.Info.Name = "."
+		t.Info.Base = "."
+		t.Info.Ext = ""
+	}
+	if !a.Config.DisableIcon {
+		t.Info.Icon = icons.OpenDir()
+	}
+}
+
+func (a *App) appendChildEntry(t *Directory, d *DirectoryEntry, de fs.DirEntry, gitRepoStatus map[string]string, isLong bool) {
+	name := de.Name()
+	fullpath := a.FS.Join(d.Name(), name)
+	fi, infoErr := de.Info() // fi might be nil on error
+	if infoErr != nil {
+		a.Logger.Printf(cannotAccessFmt, fullpath, infoErr)
+		a.ExitCode.SetMinor()
+	}
+
+	entry := a.buildEntry(fullpath, fi, isLong)
+
+	if fi == nil {
+		a.fillMissingInfo(entry, de)
+	}
+
+	if gitRepoStatus != nil {
+		entry.GitStatus = gitRepoStatus[name+a.FS.Separator()]
+		if entry.GitStatus == "" {
+			entry.GitStatus = gitRepoStatus[name]
+		}
+	}
+
+	t.Files = append(t.Files, entry)
+	if de.IsDir() {
+		t.Dirs = append(t.Dirs, name+"/")
+	}
+}
+
+func (a *App) fillMissingInfo(entry *inspect.InspectedEntry, de fs.DirEntry) {
+	if de.IsDir() {
+		entry.Indicator = "/"
+	} else if de.Type()&iofs.ModeSymlink != 0 {
+		entry.Indicator = "@"
+	}
+	if !a.Config.DisableIcon {
+		entry.Icon = icons.ResolveWith(a.IconOverride, entry.Base, entry.Ext, entry.Indicator)
+	}
+}
+
+func (a *App) appendDotEntries(t *Directory, d *DirectoryEntry, isLong bool) {
+	if t.Info != nil {
+		t.Files = append(t.Files, t.Info)
+	}
+
+	pp := a.FS.Dir(d.Name())
+	pStat, _ := a.FS.Lstat(pp)
+
+	parentEntry := a.buildEntry(pp, pStat, isLong)
+	parentEntry.Name = ".."
+	parentEntry.Base = ".."
+	parentEntry.Ext = ""
+
+	if !a.Config.DisableIcon {
+		parentEntry.Icon = icons.OpenDir()
+	}
+
+	t.Files = append(t.Files, parentEntry)
+	t.Parent = parentEntry
 }
 
 // inspectorFor builds an Inspector for exactly the columns the current mode needs.

--- a/internal/cli/parser.go
+++ b/internal/cli/parser.go
@@ -73,65 +73,91 @@ func (p *Parser) Parse(args []string) error {
 			break
 		}
 
-		if strings.HasPrefix(arg, "--") {
-			name := arg[2:]
-			var inlineValue string
-			hasInline := false
-			if eq := strings.IndexByte(name, '='); eq >= 0 {
-				inlineValue = name[eq+1:]
-				name = name[:eq]
-				hasInline = true
+		switch {
+		case strings.HasPrefix(arg, "--"):
+			consumed, err := p.parseLong(args, i)
+			if err != nil {
+				return err
 			}
-			found := false
-			for _, f := range p.Flags {
-				if f.Long != name {
-					continue
-				}
-				switch f.Type {
-				case FlagBool:
-					if hasInline {
-						return fmt.Errorf("flag --%s does not take a value", name)
-					}
-					*(f.Value.(*bool)) = true
-				case FlagString:
-					if hasInline {
-						*(f.Value.(*string)) = inlineValue
-					} else {
-						if i+1 >= len(args) {
-							return fmt.Errorf("flag --%s requires a value", name)
-						}
-						i++
-						*(f.Value.(*string)) = args[i]
-					}
-				}
-				found = true
-				break
+			i += consumed
+		case strings.HasPrefix(arg, "-") && len(arg) > 1:
+			if err := p.parseShortCluster(arg[1:]); err != nil {
+				return err
 			}
-			if !found {
-				return fmt.Errorf("unknown flag: --%s", name)
-			}
-		} else if strings.HasPrefix(arg, "-") && len(arg) > 1 {
-			chars := arg[1:]
-			for _, char := range chars {
-				found := false
-				for _, f := range p.Flags {
-					if f.Short == char {
-						if f.Type == FlagBool {
-							*(f.Value.(*bool)) = true
-							found = true
-							break
-						}
-					}
-				}
-				if !found {
-					return fmt.Errorf("unknown flag: -%c", char)
-				}
-			}
-		} else {
+		default:
 			p.Args = append(p.Args, arg)
 		}
 	}
 	return nil
+}
+
+// parseLong handles a "--name[=value]" token. Returns the number of additional
+// args consumed (0 or 1 for a value following the flag).
+func (p *Parser) parseLong(args []string, i int) (int, error) {
+	name := args[i][2:]
+	var inlineValue string
+	hasInline := false
+	if eq := strings.IndexByte(name, '='); eq >= 0 {
+		inlineValue = name[eq+1:]
+		name = name[:eq]
+		hasInline = true
+	}
+
+	f := p.findLong(name)
+	if f == nil {
+		return 0, fmt.Errorf("unknown flag: --%s", name)
+	}
+	return p.assignLong(f, name, args, i, inlineValue, hasInline)
+}
+
+func (p *Parser) findLong(name string) *Flag {
+	for _, f := range p.Flags {
+		if f.Long == name {
+			return f
+		}
+	}
+	return nil
+}
+
+func (p *Parser) assignLong(f *Flag, name string, args []string, i int, inlineValue string, hasInline bool) (int, error) {
+	switch f.Type {
+	case FlagBool:
+		if hasInline {
+			return 0, fmt.Errorf("flag --%s does not take a value", name)
+		}
+		*(f.Value.(*bool)) = true
+		return 0, nil
+	case FlagString:
+		if hasInline {
+			*(f.Value.(*string)) = inlineValue
+			return 0, nil
+		}
+		if i+1 >= len(args) {
+			return 0, fmt.Errorf("flag --%s requires a value", name)
+		}
+		*(f.Value.(*string)) = args[i+1]
+		return 1, nil
+	}
+	return 0, nil
+}
+
+func (p *Parser) parseShortCluster(chars string) error {
+	for _, char := range chars {
+		if !p.setShortBool(char) {
+			return fmt.Errorf("unknown flag: -%c", char)
+		}
+	}
+	return nil
+}
+
+func (p *Parser) setShortBool(char rune) bool {
+	for _, f := range p.Flags {
+		if f.Short == char && f.Type == FlagBool {
+			*(f.Value.(*bool)) = true
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Parser) PrintUsage() {

--- a/internal/icons/icons_test.go
+++ b/internal/icons/icons_test.go
@@ -17,7 +17,6 @@ import (
 func TestFileIcons(t *testing.T) {
 	log.Println("Printing each supported file name and ext by the icon pack")
 
-	// get terminal width
 	terminalWidth, _, e := term.GetSize(int(os.Stdout.Fd()))
 	if e != nil {
 		terminalWidth = 80
@@ -31,31 +30,31 @@ func TestFileIcons(t *testing.T) {
 
 	for _, v := range ks {
 		t.Run("Testing icon: "+v, func(st *testing.T) {
-			i := icons.IconSet[v]
-			fmt.Fprintln(os.Stderr)
-			buf := bytes.NewBuffer([]byte(""))
-			log.Println("Printing files of type", i.GetColor()+v+"\033[0m")
-			w := ctw.NewStandardCTW(terminalWidth)
-			for f, d := range icons.IconFileName {
-				if d == i {
-					w.AddRow(d.GetColor(), "    ", d.GetGlyph(), f, "")
-				}
-			}
-			w.Flush(buf)
-			io.Copy(os.Stderr, buf)
-
-			buf = bytes.NewBuffer([]byte(""))
-			log.Println("Printing extentions of type", i.GetColor()+v+"\033[0m")
-			w = ctw.NewStandardCTW(terminalWidth)
-			for e, d := range icons.IconExt {
-				if d == i {
-					w.AddRow(d.GetColor(), "    ", d.GetGlyph(), e, "")
-				}
-			}
-			w.Flush(buf)
-			io.Copy(os.Stderr, buf)
+			runIconSubtest(v, terminalWidth)
 		})
 	}
+}
+
+func runIconSubtest(name string, terminalWidth int) {
+	i := icons.IconSet[name]
+	fmt.Fprintln(os.Stderr)
+	log.Println("Printing files of type", i.GetColor()+name+"\033[0m")
+	writeMatchingEntries(terminalWidth, i, icons.IconFileName)
+
+	log.Println("Printing extentions of type", i.GetColor()+name+"\033[0m")
+	writeMatchingEntries(terminalWidth, i, icons.IconExt)
+}
+
+func writeMatchingEntries(terminalWidth int, target *icons.IconInfo, set map[string]*icons.IconInfo) {
+	buf := bytes.NewBuffer(nil)
+	w := ctw.NewStandardCTW(terminalWidth)
+	for name, info := range set {
+		if info == target {
+			w.AddRow(info.GetColor(), "    ", info.GetGlyph(), name, "")
+		}
+	}
+	w.Flush(buf)
+	io.Copy(os.Stderr, buf)
 }
 
 func TestIconDisplay(t *testing.T) {

--- a/internal/inspect/inspector.go
+++ b/internal/inspect/inspector.go
@@ -88,74 +88,95 @@ func (i *Inspector) Inspect(absPath string, fi fs.FileInfo) *InspectedEntry {
 	e.ModTime = fi.ModTime()
 	e.Kind = kindFromMode(fi.Mode())
 
-	wantStat := i.options.ShowInode || i.options.ShowBlocks || i.options.Long
-	if wantStat {
-		stat := i.platform.Read(absPath, fi, platform.Options{WantXAttr: i.options.Long && i.options.WantXAttr})
-		if i.options.ShowInode {
-			e.Inode = stat.Inode
-		}
-		if i.options.ShowBlocks {
-			e.Blocks = stat.Blocks
-			if e.Blocks == 0 && e.Kind == KindFile {
-				e.Blocks = (e.Size + 511) / 512
-			}
-		}
-		if i.options.Long {
-			e.HardLinks = stat.HardLinks
-			if e.HardLinks == 0 {
-				e.HardLinks = 1
-			}
-			e.HasXAttr = stat.HasXAttr
-			e.Sticky = stat.Sticky
-			e.StickyX = stat.StickyX
-			if no, ok := fi.(namedOwner); ok {
-				if i.options.ShowOwner {
-					e.Owner = no.OwnerName()
-				}
-				if i.options.ShowGroup {
-					e.Group = no.GroupName()
-				}
-			} else {
-				if i.options.ShowOwner {
-					e.Owner = i.platform.LookupOwner(stat.UID)
-				}
-				if i.options.ShowGroup {
-					e.Group = i.platform.LookupGroup(stat.GID)
-				}
-			}
-		}
+	if i.options.ShowInode || i.options.ShowBlocks || i.options.Long {
+		i.applyPlatformStat(e, absPath, fi)
 	}
 
 	if e.Kind == KindSymlink && (i.options.ResolveSymlinks || i.options.Long) {
-		if target, err := i.fs.EvalSymlinks(absPath); err == nil {
-			e.LinkTarget = target
-			if tfi, terr := i.fs.Stat(target); terr == nil {
-				e.LinkResolved = &InspectedEntry{
-					AbsPath: target,
-					Name:    tfi.Name(),
-					Mode:    tfi.Mode(),
-					Size:    tfi.Size(),
-					ModTime: tfi.ModTime(),
-					Kind:    kindFromMode(tfi.Mode()),
-				}
-			}
-		}
+		i.resolveSymlink(e, absPath)
 	}
 
 	e.Indicator = i.indicatorFor(e, fi.Mode())
 
 	if !i.options.DisableIcon && i.icons != nil {
-		name, ext := splitNameExt(e.Name, i.fs)
-		if e.Kind == KindSymlink && e.LinkResolved != nil {
-			tname, text := splitNameExt(e.LinkResolved.Name, i.fs)
-			tind := classifyIndicator(e.LinkResolved.Mode)
-			e.Icon = i.icons.Resolve(tname, text, tind)
-		} else {
-			e.Icon = i.icons.Resolve(name, ext, e.Indicator)
-		}
+		e.Icon = i.resolveIcon(e)
 	}
 
 	return e
+}
+
+func (i *Inspector) applyPlatformStat(e *InspectedEntry, absPath string, fi fs.FileInfo) {
+	stat := i.platform.Read(absPath, fi, platform.Options{WantXAttr: i.options.Long && i.options.WantXAttr})
+	if i.options.ShowInode {
+		e.Inode = stat.Inode
+	}
+	if i.options.ShowBlocks {
+		e.Blocks = stat.Blocks
+		if e.Blocks == 0 && e.Kind == KindFile {
+			e.Blocks = (e.Size + 511) / 512
+		}
+	}
+	if i.options.Long {
+		i.applyLongStat(e, fi, stat)
+	}
+}
+
+func (i *Inspector) applyLongStat(e *InspectedEntry, fi fs.FileInfo, stat platform.Stat) {
+	e.HardLinks = stat.HardLinks
+	if e.HardLinks == 0 {
+		e.HardLinks = 1
+	}
+	e.HasXAttr = stat.HasXAttr
+	e.Sticky = stat.Sticky
+	e.StickyX = stat.StickyX
+	i.applyOwnerGroup(e, fi, stat)
+}
+
+func (i *Inspector) applyOwnerGroup(e *InspectedEntry, fi fs.FileInfo, stat platform.Stat) {
+	if no, ok := fi.(namedOwner); ok {
+		if i.options.ShowOwner {
+			e.Owner = no.OwnerName()
+		}
+		if i.options.ShowGroup {
+			e.Group = no.GroupName()
+		}
+		return
+	}
+	if i.options.ShowOwner {
+		e.Owner = i.platform.LookupOwner(stat.UID)
+	}
+	if i.options.ShowGroup {
+		e.Group = i.platform.LookupGroup(stat.GID)
+	}
+}
+
+func (i *Inspector) resolveSymlink(e *InspectedEntry, absPath string) {
+	target, err := i.fs.EvalSymlinks(absPath)
+	if err != nil {
+		return
+	}
+	e.LinkTarget = target
+	tfi, terr := i.fs.Stat(target)
+	if terr != nil {
+		return
+	}
+	e.LinkResolved = &InspectedEntry{
+		AbsPath: target,
+		Name:    tfi.Name(),
+		Mode:    tfi.Mode(),
+		Size:    tfi.Size(),
+		ModTime: tfi.ModTime(),
+		Kind:    kindFromMode(tfi.Mode()),
+	}
+}
+
+func (i *Inspector) resolveIcon(e *InspectedEntry) *icons.IconInfo {
+	if e.Kind == KindSymlink && e.LinkResolved != nil {
+		tname, text := splitNameExt(e.LinkResolved.Name, i.fs)
+		return i.icons.Resolve(tname, text, classifyIndicator(e.LinkResolved.Mode))
+	}
+	name, ext := splitNameExt(e.Name, i.fs)
+	return i.icons.Resolve(name, ext, e.Indicator)
 }
 
 // indicatorFor returns the trailing classifier glyph ("/", "@", "*", ...).

--- a/internal/render/columns/long_ctw.go
+++ b/internal/render/columns/long_ctw.go
@@ -53,48 +53,40 @@ func (l *LongCTW) Flush(buf *bytes.Buffer) {
 	l.columnWidths[l.numCols-2] = 1 // icon column
 
 	for rowIdx, row := range l.rows {
-		isFirstPrintedCol := true
+		l.writeRow(buf, rowIdx, row, skipCols)
+	}
+}
 
-		for colIdx, cellValue := range row {
-			if skipCols[colIdx] {
-				continue
-			}
-
-			if !isFirstPrintedCol {
-				fmt.Fprint(buf, l.empty)
-			}
-
-			switch {
-			case colIdx == l.numCols-2:
-				fmt.Fprintf(buf, "%s%*s%s",
-					l.iconColors[rowIdx],
-					l.columnWidths[colIdx],
-					cellValue,
-					l.noColor,
-				)
-
-			case colIdx >= l.numCols-1 && !skipCols[l.numCols]:
-				gitColor := l.GetGitColor(row[l.numCols])
-				fmt.Fprintf(buf, "%s%-*s%s",
-					gitColor,
-					l.columnWidths[colIdx],
-					cellValue,
-					l.noColor,
-				)
-
-			case skipCols[l.numCols] && colIdx == l.numCols-1:
-				fmt.Fprintf(buf, "%-*s", l.columnWidths[colIdx], cellValue)
-
-			// permission column is left-aligned
-			case !skipCols[l.numCols] && colIdx == 1:
-				fmt.Fprintf(buf, "%-*s", l.columnWidths[colIdx], cellValue)
-
-			default:
-				fmt.Fprintf(buf, "%*s", l.columnWidths[colIdx], cellValue)
-			}
-
-			isFirstPrintedCol = false
+func (l *LongCTW) writeRow(buf *bytes.Buffer, rowIdx int, row []string, skipCols []bool) {
+	isFirstPrintedCol := true
+	for colIdx, cellValue := range row {
+		if skipCols[colIdx] {
+			continue
 		}
-		fmt.Fprintln(buf)
+		if !isFirstPrintedCol {
+			fmt.Fprint(buf, l.empty)
+		}
+		l.writeCell(buf, rowIdx, colIdx, cellValue, row, skipCols)
+		isFirstPrintedCol = false
+	}
+	fmt.Fprintln(buf)
+}
+
+func (l *LongCTW) writeCell(buf *bytes.Buffer, rowIdx, colIdx int, cellValue string, row []string, skipCols []bool) {
+	gitSkipped := skipCols[l.numCols]
+	width := l.columnWidths[colIdx]
+
+	switch {
+	case colIdx == l.numCols-2:
+		fmt.Fprintf(buf, "%s%*s%s", l.iconColors[rowIdx], width, cellValue, l.noColor)
+	case colIdx >= l.numCols-1 && !gitSkipped:
+		fmt.Fprintf(buf, "%s%-*s%s", l.GetGitColor(row[l.numCols]), width, cellValue, l.noColor)
+	case gitSkipped && colIdx == l.numCols-1:
+		fmt.Fprintf(buf, "%-*s", width, cellValue)
+	case !gitSkipped && colIdx == 1:
+		// permission column is left-aligned
+		fmt.Fprintf(buf, "%-*s", width, cellValue)
+	default:
+		fmt.Fprintf(buf, "%*s", width, cellValue)
 	}
 }

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -58,8 +58,7 @@ func Render(w io.Writer, entries []*inspect.InspectedEntry, opts Options) {
 
 func addRow(tw ctw.CTW, e *inspect.InspectedEntry, opts Options) {
 	displayName := e.Base + e.Ext + e.Indicator
-	switch opts.Mode {
-	case ModeLong:
+	if opts.Mode == ModeLong {
 		tw.AddRow(
 			e.Icon.GetColor(),
 			blockSizeWithInode(e, opts),
@@ -73,23 +72,15 @@ func addRow(tw ctw.CTW, e *inspect.InspectedEntry, opts Options) {
 			displayName,
 			e.GitStatus,
 		)
-	case ModeOneFilePerLine:
-		tw.AddRow(
-			e.Icon.GetColor(),
-			blockSizeWithInode(e, opts),
-			e.Icon.GetGlyph(),
-			displayName,
-			e.GitStatus,
-		)
-	default:
-		tw.AddRow(
-			e.Icon.GetColor(),
-			blockSizeWithInode(e, opts),
-			e.Icon.GetGlyph(),
-			displayName,
-			e.GitStatus,
-		)
+		return
 	}
+	tw.AddRow(
+		e.Icon.GetColor(),
+		blockSizeWithInode(e, opts),
+		e.Icon.GetGlyph(),
+		displayName,
+		e.GitStatus,
+	)
 }
 
 func hardLinks(e *inspect.InspectedEntry) uint64 {

--- a/internal/sort/sort.go
+++ b/internal/sort/sort.go
@@ -29,57 +29,74 @@ func Sort(entries []*inspect.InspectedEntry, mode cli.SortMode, reverse bool) {
 func lessFn(entries []*inspect.InspectedEntry, mode cli.SortMode) func(i, j int) bool {
 	switch mode {
 	case cli.SortAlphabetical:
-		return func(i, j int) bool {
-			return mainSort(entries[i].Name, entries[j].Name)
-		}
+		return lessAlpha(entries)
 	case cli.SortSize:
-		return func(i, j int) bool {
-			a, b := entries[i].Name, entries[j].Name
-			if res, ok := dotFileOrder(a, b); ok {
-				return res
-			}
-			if entries[i].Size > entries[j].Size {
-				return true
-			}
-			if entries[i].Size == entries[j].Size {
-				return mainSort(a, b)
-			}
-			return false
-		}
+		return lessSize(entries)
 	case cli.SortModTime:
-		return func(i, j int) bool {
-			return entries[i].ModTime.After(entries[j].ModTime)
-		}
+		return lessModTime(entries)
 	case cli.SortExtension:
-		return func(i, j int) bool {
-			a, b := entries[i].Name, entries[j].Name
-			ra := extGroupRank(entries[i].Base, entries[i].Ext)
-			rb := extGroupRank(entries[j].Base, entries[j].Ext)
-			if ra != rb {
-				return ra < rb
-			}
-			if ra == 2 {
-				if compareName(entries[i].Ext, entries[j].Ext) {
-					return true
-				}
-				if compareName(entries[j].Ext, entries[i].Ext) {
-					return false
-				}
-			}
-			return mainSort(a, b)
-		}
+		return lessExtension(entries)
 	case cli.SortNatural:
-		return func(i, j int) bool {
-			a, b := entries[i].Name, entries[j].Name
-			if res, ok := dotFileOrder(a, b); ok {
-				return res
-			}
-			return a < b
-		}
+		return lessNatural(entries)
 	case cli.SortNone:
 		fallthrough
 	default:
 		return func(i, j int) bool { return i < j }
+	}
+}
+
+func lessAlpha(entries []*inspect.InspectedEntry) func(i, j int) bool {
+	return func(i, j int) bool {
+		return mainSort(entries[i].Name, entries[j].Name)
+	}
+}
+
+func lessSize(entries []*inspect.InspectedEntry) func(i, j int) bool {
+	return func(i, j int) bool {
+		a, b := entries[i].Name, entries[j].Name
+		if res, ok := dotFileOrder(a, b); ok {
+			return res
+		}
+		if entries[i].Size != entries[j].Size {
+			return entries[i].Size > entries[j].Size
+		}
+		return mainSort(a, b)
+	}
+}
+
+func lessModTime(entries []*inspect.InspectedEntry) func(i, j int) bool {
+	return func(i, j int) bool {
+		return entries[i].ModTime.After(entries[j].ModTime)
+	}
+}
+
+func lessExtension(entries []*inspect.InspectedEntry) func(i, j int) bool {
+	return func(i, j int) bool {
+		a, b := entries[i].Name, entries[j].Name
+		ra := extGroupRank(entries[i].Base, entries[i].Ext)
+		rb := extGroupRank(entries[j].Base, entries[j].Ext)
+		if ra != rb {
+			return ra < rb
+		}
+		if ra == 2 {
+			if compareName(entries[i].Ext, entries[j].Ext) {
+				return true
+			}
+			if compareName(entries[j].Ext, entries[i].Ext) {
+				return false
+			}
+		}
+		return mainSort(a, b)
+	}
+}
+
+func lessNatural(entries []*inspect.InspectedEntry) func(i, j int) bool {
+	return func(i, j int) bool {
+		a, b := entries[i].Name, entries[j].Name
+		if res, ok := dotFileOrder(a, b); ok {
+			return res
+		}
+		return a < b
 	}
 }
 


### PR DESCRIPTION
Ran a sonarqube scan which identified some methods with high cognitive complexity. So, since I'm on a refactoring streak, I decided to refactor those methods breaking them in multiple smaller methods. Overall it fells like the code is easier to read.
